### PR TITLE
GRIDEDIT-1937: Add zero-initialized memory allocation for unmanaged mesh data structures

### DIFF
--- a/libs/UGridNET/dll/src/ContactsExtensions.cs
+++ b/libs/UGridNET/dll/src/ContactsExtensions.cs
@@ -13,13 +13,13 @@ namespace UGridNET
             {
                 try
                 {
-                    contacts.name = IntPtrHelpers.Allocate<byte>(UGrid.name_long_length);
-                    contacts.contact_name_id = IntPtrHelpers.Allocate<byte>(UGrid.name_long_length * contacts.num_contacts);
-                    contacts.mesh_from_name = IntPtrHelpers.Allocate<byte>(UGrid.name_long_length);
-                    contacts.mesh_to_name = IntPtrHelpers.Allocate<byte>(UGrid.name_long_length);
-                    contacts.contact_name_long = IntPtrHelpers.Allocate<byte>(UGrid.name_long_length * contacts.num_contacts);
-                    contacts.edges = IntPtrHelpers.Allocate<int>(contacts.num_contacts * 2);
-                    contacts.contact_type = IntPtrHelpers.Allocate<int>(contacts.num_contacts);
+                    contacts.name = IntPtrHelpers.AllocateZeroed<byte>(UGrid.name_long_length);
+                    contacts.contact_name_id = IntPtrHelpers.AllocateZeroed<byte>(UGrid.name_long_length * contacts.num_contacts);
+                    contacts.mesh_from_name = IntPtrHelpers.AllocateZeroed<byte>(UGrid.name_long_length);
+                    contacts.mesh_to_name = IntPtrHelpers.AllocateZeroed<byte>(UGrid.name_long_length);
+                    contacts.contact_name_long = IntPtrHelpers.AllocateZeroed<byte>(UGrid.name_long_length * contacts.num_contacts);
+                    contacts.edges = IntPtrHelpers.AllocateZeroed<int>(contacts.num_contacts * 2);
+                    contacts.contact_type = IntPtrHelpers.AllocateZeroed<int>(contacts.num_contacts);
                 }
                 catch
                 {

--- a/libs/UGridNET/dll/src/IntPtrHelpers.cs
+++ b/libs/UGridNET/dll/src/IntPtrHelpers.cs
@@ -9,14 +9,27 @@ namespace UGridNET
         /// <typeparam name="T"> The type of elements for which memory is being allocated. </typeparam>
         /// <param name="count">The number of elements to allocate memory for.</param>
         /// <returns> A pointer to the allocated unmanaged memory if <paramref name="count"/> is strictly positive, IntPtr.Zero otherwise . </returns>
-        /// <remarks> The caller is responsible for freeing the memory using <see cref="Free"/>. </remarks>
+        /// <remarks> The caller is responsible for freeing the memory using <see cref="Free(ref System.IntPtr)"/>. </remarks>
         public static IntPtr Allocate<T>(int count) where T : struct
         {
             return count > 0 ? Marshal.AllocHGlobal(count * Marshal.SizeOf<T>()) : IntPtr.Zero;
         }
+        
+        /// <summary> Allocates unmanaged memory for an array of elements of the specified type and initializes it to zero. </summary>
+        /// <typeparam name="T"> The type of elements for which memory is being allocated. </typeparam>
+        /// <param name="count">The number of elements to allocate memory for.</param>
+        /// <returns> A pointer to the allocated and zero-initialized unmanaged memory if <paramref name="count"/> is strictly positive, IntPtr.Zero otherwise. </returns>
+        /// <remarks> The caller is responsible for freeing the memory using <see cref="Free(ref System.IntPtr)"/>. </remarks>
+        public static IntPtr AllocateZeroed<T>(int count) where T : struct
+        {
+            var ptr = Allocate<T>(count);
+            if (ptr == IntPtr.Zero) return ptr;
+            var totalBytes = count * Marshal.SizeOf<T>();
+            Marshal.Copy(new byte[totalBytes], 0, ptr, totalBytes);
+            return ptr;
+        }
 
-
-        /// <summary> Frees unmanaged memory previously allocated with <see cref="Allocate"/>. </summary>
+        /// <summary> Frees unmanaged memory previously allocated with <see cref="Allocate{T}"/>. </summary>
         /// <param name="ptr"> A pointer to the unmanaged memory to free.</param>
         public static void Free(ref IntPtr ptr)
         {
@@ -25,7 +38,7 @@ namespace UGridNET
             ptr = IntPtr.Zero;
         }
 
-        /// <summary> Frees unmanaged memory previously allocated with <see cref="Allocate"/>. </summary>
+        /// <summary> Frees unmanaged memory previously allocated with <see cref="Allocate{T}"/>. </summary>
         /// <param name="getPtr">A function that returns the pointer to the unmanaged memory block.</param>
         /// <param name="setPtr">An action that sets the pointer to <see cref="IntPtr.Zero"/> after freeing the memory.</param>
         /// <remarks>
@@ -42,7 +55,6 @@ namespace UGridNET
             Marshal.FreeHGlobal(ptr);
             setPtr(IntPtr.Zero);
         }
-
     }
 
 }

--- a/libs/UGridNET/dll/src/Mesh1DExtensions.cs
+++ b/libs/UGridNET/dll/src/Mesh1DExtensions.cs
@@ -13,17 +13,17 @@ namespace UGridNET
             {
                 try
                 {
-                    mesh1D.name = IntPtrHelpers.Allocate<byte>(UGrid.name_long_length);
-                    mesh1D.node_long_name = IntPtrHelpers.Allocate<byte>(UGrid.name_long_length * mesh1D.num_nodes);
-                    mesh1D.network_name = IntPtrHelpers.Allocate<byte>(UGrid.name_long_length);
-                    mesh1D.node_x = IntPtrHelpers.Allocate<double>(mesh1D.num_nodes);
-                    mesh1D.node_y = IntPtrHelpers.Allocate<double>(mesh1D.num_nodes);
-                    mesh1D.edge_x = IntPtrHelpers.Allocate<double>(mesh1D.num_edges);
-                    mesh1D.edge_y = IntPtrHelpers.Allocate<double>(mesh1D.num_edges);
-                    mesh1D.edge_nodes = IntPtrHelpers.Allocate<int>(mesh1D.num_edges * 2);
-                    mesh1D.edge_edge_id = IntPtrHelpers.Allocate<int>(mesh1D.num_edges);
-                    mesh1D.node_edge_id = IntPtrHelpers.Allocate<int>(mesh1D.num_nodes);
-                    mesh1D.node_edge_offset = IntPtrHelpers.Allocate<double>(mesh1D.num_nodes);
+                    mesh1D.name = IntPtrHelpers.AllocateZeroed<byte>(UGrid.name_long_length);
+                    mesh1D.node_long_name = IntPtrHelpers.AllocateZeroed<byte>(UGrid.name_long_length * mesh1D.num_nodes);
+                    mesh1D.network_name = IntPtrHelpers.AllocateZeroed<byte>(UGrid.name_long_length);
+                    mesh1D.node_x = IntPtrHelpers.AllocateZeroed<double>(mesh1D.num_nodes);
+                    mesh1D.node_y = IntPtrHelpers.AllocateZeroed<double>(mesh1D.num_nodes);
+                    mesh1D.edge_x = IntPtrHelpers.AllocateZeroed<double>(mesh1D.num_edges);
+                    mesh1D.edge_y = IntPtrHelpers.AllocateZeroed<double>(mesh1D.num_edges);
+                    mesh1D.edge_nodes = IntPtrHelpers.AllocateZeroed<int>(mesh1D.num_edges * 2);
+                    mesh1D.edge_edge_id = IntPtrHelpers.AllocateZeroed<int>(mesh1D.num_edges);
+                    mesh1D.node_edge_id = IntPtrHelpers.AllocateZeroed<int>(mesh1D.num_nodes);
+                    mesh1D.node_edge_offset = IntPtrHelpers.AllocateZeroed<double>(mesh1D.num_nodes);
                 }
                 catch
                 {

--- a/libs/UGridNET/dll/src/Mesh2DExtensions.cs
+++ b/libs/UGridNET/dll/src/Mesh2DExtensions.cs
@@ -13,21 +13,21 @@ namespace UGridNET
             {
                 try
                 {
-                    mesh2D.name = IntPtrHelpers.Allocate<byte>(UGrid.name_long_length);
-                    mesh2D.node_x = IntPtrHelpers.Allocate<double>(mesh2D.num_nodes);
-                    mesh2D.node_y = IntPtrHelpers.Allocate<double>(mesh2D.num_nodes);
-                    mesh2D.node_z = IntPtrHelpers.Allocate<double>(mesh2D.num_nodes);
-                    mesh2D.edge_x = IntPtrHelpers.Allocate<double>(mesh2D.num_edges);
-                    mesh2D.edge_y = IntPtrHelpers.Allocate<double>(mesh2D.num_edges);
-                    mesh2D.edge_z = IntPtrHelpers.Allocate<double>(mesh2D.num_edges);
-                    mesh2D.face_x = IntPtrHelpers.Allocate<double>(mesh2D.num_faces);
-                    mesh2D.face_y = IntPtrHelpers.Allocate<double>(mesh2D.num_faces);
-                    mesh2D.face_z = IntPtrHelpers.Allocate<double>(mesh2D.num_faces);
-                    mesh2D.edge_nodes = IntPtrHelpers.Allocate<int>(mesh2D.num_edges * 2);
-                    mesh2D.edge_faces = IntPtrHelpers.Allocate<int>(mesh2D.num_edges * 2);
-                    mesh2D.face_nodes = IntPtrHelpers.Allocate<int>(mesh2D.num_faces * mesh2D.num_face_nodes_max);
-                    mesh2D.face_edges = IntPtrHelpers.Allocate<int>(mesh2D.num_faces * mesh2D.num_face_nodes_max);
-                    mesh2D.face_faces = IntPtrHelpers.Allocate<int>(mesh2D.num_faces * mesh2D.num_face_nodes_max);
+                    mesh2D.name = IntPtrHelpers.AllocateZeroed<byte>(UGrid.name_long_length);
+                    mesh2D.node_x = IntPtrHelpers.AllocateZeroed<double>(mesh2D.num_nodes);
+                    mesh2D.node_y = IntPtrHelpers.AllocateZeroed<double>(mesh2D.num_nodes);
+                    mesh2D.node_z = IntPtrHelpers.AllocateZeroed<double>(mesh2D.num_nodes);
+                    mesh2D.edge_x = IntPtrHelpers.AllocateZeroed<double>(mesh2D.num_edges);
+                    mesh2D.edge_y = IntPtrHelpers.AllocateZeroed<double>(mesh2D.num_edges);
+                    mesh2D.edge_z = IntPtrHelpers.AllocateZeroed<double>(mesh2D.num_edges);
+                    mesh2D.face_x = IntPtrHelpers.AllocateZeroed<double>(mesh2D.num_faces);
+                    mesh2D.face_y = IntPtrHelpers.AllocateZeroed<double>(mesh2D.num_faces);
+                    mesh2D.face_z = IntPtrHelpers.AllocateZeroed<double>(mesh2D.num_faces);
+                    mesh2D.edge_nodes = IntPtrHelpers.AllocateZeroed<int>(mesh2D.num_edges * 2);
+                    mesh2D.edge_faces = IntPtrHelpers.AllocateZeroed<int>(mesh2D.num_edges * 2);
+                    mesh2D.face_nodes = IntPtrHelpers.AllocateZeroed<int>(mesh2D.num_faces * mesh2D.num_face_nodes_max);
+                    mesh2D.face_edges = IntPtrHelpers.AllocateZeroed<int>(mesh2D.num_faces * mesh2D.num_face_nodes_max);
+                    mesh2D.face_faces = IntPtrHelpers.AllocateZeroed<int>(mesh2D.num_faces * mesh2D.num_face_nodes_max);
                 }
                 catch
                 {

--- a/libs/UGridNET/dll/src/Network1DExtensions.cs
+++ b/libs/UGridNET/dll/src/Network1DExtensions.cs
@@ -13,19 +13,19 @@ namespace UGridNET
             {
                 try
                 {
-                    network1D.name = IntPtrHelpers.Allocate<byte>(UGrid.name_long_length);
-                    network1D.node_id = IntPtrHelpers.Allocate<byte>(UGrid.name_length * network1D.num_nodes);
-                    network1D.node_long_name = IntPtrHelpers.Allocate<byte>(UGrid.name_long_length * network1D.num_nodes);
-                    network1D.edge_id = IntPtrHelpers.Allocate<byte>(UGrid.name_length * network1D.num_edges);
-                    network1D.edge_long_name = IntPtrHelpers.Allocate<byte>(UGrid.name_long_length * network1D.num_edges);
-                    network1D.node_x = IntPtrHelpers.Allocate<double>(network1D.num_nodes);
-                    network1D.node_y = IntPtrHelpers.Allocate<double>(network1D.num_nodes);
-                    network1D.edge_nodes = IntPtrHelpers.Allocate<int>(network1D.num_edges * 2);
-                    network1D.edge_length = IntPtrHelpers.Allocate<double>(network1D.num_edges);
-                    network1D.edge_order = IntPtrHelpers.Allocate<int>(network1D.num_edges);
-                    network1D.geometry_nodes_x = IntPtrHelpers.Allocate<double>(network1D.num_geometry_nodes);
-                    network1D.geometry_nodes_y = IntPtrHelpers.Allocate<double>(network1D.num_geometry_nodes);
-                    network1D.num_edge_geometry_nodes = IntPtrHelpers.Allocate<int>(network1D.num_edges);
+                    network1D.name = IntPtrHelpers.AllocateZeroed<byte>(UGrid.name_long_length);
+                    network1D.node_id = IntPtrHelpers.AllocateZeroed<byte>(UGrid.name_length * network1D.num_nodes);
+                    network1D.node_long_name = IntPtrHelpers.AllocateZeroed<byte>(UGrid.name_long_length * network1D.num_nodes);
+                    network1D.edge_id = IntPtrHelpers.AllocateZeroed<byte>(UGrid.name_length * network1D.num_edges);
+                    network1D.edge_long_name = IntPtrHelpers.AllocateZeroed<byte>(UGrid.name_long_length * network1D.num_edges);
+                    network1D.node_x = IntPtrHelpers.AllocateZeroed<double>(network1D.num_nodes);
+                    network1D.node_y = IntPtrHelpers.AllocateZeroed<double>(network1D.num_nodes);
+                    network1D.edge_nodes = IntPtrHelpers.AllocateZeroed<int>(network1D.num_edges * 2);
+                    network1D.edge_length = IntPtrHelpers.AllocateZeroed<double>(network1D.num_edges);
+                    network1D.edge_order = IntPtrHelpers.AllocateZeroed<int>(network1D.num_edges);
+                    network1D.geometry_nodes_x = IntPtrHelpers.AllocateZeroed<double>(network1D.num_geometry_nodes);
+                    network1D.geometry_nodes_y = IntPtrHelpers.AllocateZeroed<double>(network1D.num_geometry_nodes);
+                    network1D.num_edge_geometry_nodes = IntPtrHelpers.AllocateZeroed<int>(network1D.num_edges);
                 }
                 catch
                 {

--- a/libs/UGridNET/test/src/IntPtrHelpersTests.cs
+++ b/libs/UGridNET/test/src/IntPtrHelpersTests.cs
@@ -7,41 +7,87 @@ namespace UGridNET.Tests
 {
     public class IntPtrHelpersBasicTests
     {
-        private static IEnumerable<TestCaseData> AllocateTestCases()
+        [Test]
+        public void AllocateValidTypeReturnsNonZeroPointerInt()
         {
-            yield return new TestCaseData(typeof(int), 10);
-            yield return new TestCaseData(typeof(double), 10);
-            yield return new TestCaseData(typeof(byte), 10);
+            AllocateValidTypeReturnsNonZeroPointer<int>(10);
         }
-
-        private IntPtr AllocateHelper(Type type, int count)
+        
+        [Test]
+        public void AllocateValidTypeReturnsNonZeroPointerDouble()
         {
-            if (type == typeof(int))
-            {
-                return IntPtrHelpers.Allocate<int>(count);
-            }
-            else if (type == typeof(double))
-            {
-                return IntPtrHelpers.Allocate<double>(count);
-            }
-            else if (type == typeof(byte))
-            {
-                return IntPtrHelpers.Allocate<byte>(count);
-            }
-            else
-            {
-                throw new ArgumentException("Type not covered by test", nameof(type));
-            }
+            AllocateValidTypeReturnsNonZeroPointer<double>(10);
         }
-
-        [Test, TestCaseSource(nameof(AllocateTestCases))]
-        public void AllocateValidTypeReturnsNonZeroPointer(Type type, int count)
+        
+        [Test]
+        public void AllocateValidTypeReturnsNonZeroPointerByte()
+        {
+            AllocateValidTypeReturnsNonZeroPointer<byte>(10);
+        }
+        
+        private void AllocateValidTypeReturnsNonZeroPointer<T>(int count) where T : struct
         {
             var ptr = IntPtr.Zero;
-            Assert.DoesNotThrow(() => ptr = AllocateHelper(type, count));
+            Assert.DoesNotThrow(() => ptr = IntPtrHelpers.Allocate<T>(count));
             Assert.That(ptr, Is.Not.EqualTo(IntPtr.Zero));
             IntPtrHelpers.Free(ref ptr);
-            Assert.That(ptr, Is.EqualTo(IntPtr.Zero));
+        }
+
+        [Test]
+        public void AllocateZeroedValidTypeReturnsNonZeroPointerInt()
+        {
+            AllocateZeroedValidTypeReturnsNonZeroPointer<int>(10);
+        }
+        
+        [Test]
+        public void AllocateZeroedValidTypeReturnsNonZeroPointerDouble()
+        {
+            AllocateZeroedValidTypeReturnsNonZeroPointer<double>(10);
+        }
+        
+        [Test]
+        public void AllocateZeroedValidTypeReturnsNonZeroPointerByte()
+        {
+            AllocateZeroedValidTypeReturnsNonZeroPointer<byte>(10);
+        }
+        
+        private void AllocateZeroedValidTypeReturnsNonZeroPointer<T>(int count) where T : struct
+        {
+            var ptr = IntPtr.Zero;
+            Assert.DoesNotThrow(() => ptr = IntPtrHelpers.AllocateZeroed<T>(count));
+            Assert.That(ptr, Is.Not.EqualTo(IntPtr.Zero));
+            IntPtrHelpers.Free(ref ptr);
+        }
+
+        [Test]
+        public void AllocateZeroedInitializesMemoryToZeroInt()
+        {
+            AllocateZeroedInitializesMemoryToZero<int>(5);
+        }
+
+        [Test]
+        public void AllocateZeroedInitializesMemoryToZeroDouble()
+        {
+            AllocateZeroedInitializesMemoryToZero<double>(5);
+        }
+
+        [Test]
+        public void AllocateZeroedInitializesMemoryToZeroByte()
+        {
+            AllocateZeroedInitializesMemoryToZero<byte>(5);
+        }
+
+        private void AllocateZeroedInitializesMemoryToZero<T>(int count) where T : struct
+        {
+            var ptr = IntPtrHelpers.AllocateZeroed<T>(count);
+
+            var totalBytes = count * Marshal.SizeOf<T>();
+            var buffer = new byte[totalBytes];
+            Marshal.Copy(ptr, buffer, 0, totalBytes);
+
+            Assert.That(buffer, Is.All.Zero);
+
+            IntPtrHelpers.Free(ref ptr);
         }
     }
 


### PR DESCRIPTION
Benchmark of `Mesh2DExtensions.Allocate` for a 2D mesh with 1,000,000 cells:

| Method   | Mean     | Error    | StdDev   | Allocated |
|--------- |---------:|---------:|---------:|----------:|
| Allocate | 57.02 ms | 2.977 ms | 8.777 ms | 167.97 MB |



