### PR TITLE
GRIDEDIT-2245: Updated UGRID file format to comply with CF conventions

### DIFF
--- a/UGrid/libs/UGrid/include/UGrid/UGridEntity.hpp
+++ b/UGrid/libs/UGrid/include/UGrid/UGridEntity.hpp
@@ -255,7 +255,7 @@ namespace ugrid
 
         /// @brief Creates a vector of coordinate variable attributes
         /// @param units [in] The units of the coordinate (e.g. "m", "degrees_east")
-        /// @param standard_name [in] The CF standard name of the coordinate (e.g. "projection_x_coordinate")
+        /// @param standard_name [in] The CF standard name of the coordinate (e.g. "projection_x_coordinate", "longitude")
         /// @param long_name [in] A descriptive name for the variable
         /// @return A vector of name-value attribute pairs.
         [[nodiscard]] std::vector<std::pair<std::string, std::string>> create_coordinate_variable_attributes(

--- a/UGrid/libs/UGrid/include/UGrid/UGridEntity.hpp
+++ b/UGrid/libs/UGrid/include/UGrid/UGridEntity.hpp
@@ -209,12 +209,14 @@ namespace ugrid
         /// @param nc_type [in] The variable type (int, float, char).
         /// @param ugridfile_dimensions [in] The variable dimensions (multidimensional variable are expressed as vectors).
         /// @param attributes [in] Any additional variable attributes.
+        /// @param add_start_index [in] Boolean to determine if the start index should be used for index variables.
         /// @param add_fill_value [in] Boolean to determine if a fill value should be used for empty data.
         void define_topological_variable(std::string const& topology_attribute_name,
                                          std::string const& variable_suffix,
                                          netCDF::NcType nc_type,
                                          std::vector<UGridFileDimensions> const& ugridfile_dimensions,
                                          std::vector<std::pair<std::string, std::string>> const& attributes = {},
+                                         bool add_start_index = false,
                                          bool add_fill_value = false);
 
         /// @brief Defines a new topology-related variable.

--- a/UGrid/libs/UGrid/include/UGrid/UGridEntity.hpp
+++ b/UGrid/libs/UGrid/include/UGrid/UGridEntity.hpp
@@ -120,6 +120,13 @@ namespace ugrid
             return m_entity_name;
         }
 
+        /// @brief Gets the name of the variable that defines the coordinate system
+        /// @return The grid mapping name
+        [[nodiscard]] const auto& get_grid_mapping() const
+        {
+            return m_grid_mapping;
+        }
+
         /// @brief Gets a vector of nc variables
         /// @param attribute_name The attribute name
         /// @return The vector of nc variables
@@ -172,7 +179,8 @@ namespace ugrid
         /// @param long_name [in] The entity long name
         /// @param topology_dimension [in] The dimension of the topology
         /// @param is_spherical [in] 1 if coordinates are in a spherical system, 0 otherwise
-        void define(char const* const entity_name, int start_index, std::string const& long_name, int topology_dimension, int is_spherical);
+        /// @param grid_mapping [in] The name of the variable that defines the coordinate system
+        void define(char const* const entity_name, int start_index, std::string const& long_name, int topology_dimension, int is_spherical, char const* const grid_mapping);
 
         /// @brief A function to determine if a variable is a topology variable (this function might get overwritten in derived if necessary)
         /// @param attributes [in] The variable attributes
@@ -243,10 +251,27 @@ namespace ugrid
                                                  std::string const& topology_attribute_name = "",
                                                  std::string const& attribute_name = "");
 
-        /// @brief Get the location attribute variable based on \ref m_spherical_coordinates value
-        /// @param location [in] The location (node, edge, face)
-        /// @return The location string appended with "x"/"y" or "lat"/"lon"
-        std::string get_location_attribute_value(std::string const& location);
+        /// @brief Creates a vector of coordinate variable attributes
+        /// @param units [in] The units of the coordinate (e.g. "m", "degrees_east")
+        /// @param standard_name [in] The CF standard name of the coordinate (e.g. "projection_x_coordinate")
+        /// @param long_name [in] A descriptive name for the variable
+        /// @return A vector of name-value attribute pairs.
+        [[nodiscard]] std::vector<std::pair<std::string, std::string>> create_coordinate_variable_attributes(
+            std::string const& units,
+            std::string const& standard_name,
+            std::string const& long_name);
+
+        /// @brief Creates a vector of data variable attributes
+        /// @param standard_name [in] The CF standard name of the variable (e.g. "altitude")
+        /// @param long_name [in] A descriptive name for the variable
+        /// @param units [in] The units of the variable (e.g. "m")
+        /// @param location [in] The entity location (node, edge or face)
+        /// @return A vector of name-value attribute pairs.
+        [[nodiscard]] std::vector<std::pair<std::string, std::string>> create_data_variable_attributes(
+            std::string const& standard_name,
+            std::string const& long_name,
+            std::string const& units,
+            UGridEntityLocations location);
 
         std::shared_ptr<netCDF::NcFile> m_nc_file;                                              ///< A pointer to the opened file
         netCDF::NcVar m_topology_variable;                                                      ///< The topology variable
@@ -258,6 +283,7 @@ namespace ugrid
         std::map<std::string, netCDF::NcVar> m_related_variables;      ///< Additional variables related to the entity (for example defined on node, edge or face)
         std::string m_entity_name = "";                                ///< The name of the entity
 
+        std::string m_grid_mapping = "";                   ///< The name of the variable that defines the coordinate system
         bool m_spherical_coordinates = false;              ///< If it is a spherical entity
         int m_start_index = 0;                             ///< The start index
         int m_int_fill_value = int_missing_value;          ///< The fill value for arrays of int

--- a/UGrid/libs/UGrid/src/Mesh1D.cpp
+++ b/UGrid/libs/UGrid/src/Mesh1D.cpp
@@ -65,7 +65,7 @@ void Mesh1D::define(ugridapi::Mesh1D const& mesh1d)
         throw std::invalid_argument("Mesh1D::define mesh1d node edge offset is empty");
     }
 
-    UGridEntity::define(mesh1d.name, mesh1d.start_index, "Topology data of 1D mesh", 1, mesh1d.is_spherical);
+    UGridEntity::define(mesh1d.name, mesh1d.start_index, "Topology data of 1D mesh", 1, mesh1d.is_spherical, mesh1d.grid_mapping);
     auto string_builder = UGridVarAttributeStringBuilder(m_entity_name);
 
     std::string network_name(mesh1d.network_name);

--- a/UGrid/libs/UGrid/src/Mesh1D.cpp
+++ b/UGrid/libs/UGrid/src/Mesh1D.cpp
@@ -146,7 +146,7 @@ void Mesh1D::define(ugridapi::Mesh1D const& mesh1d)
                                     netCDF::NcType::nc_INT,
                                     {UGridFileDimensions::edge, UGridFileDimensions::Two},
                                     {{"cf_role", topology_attribute.getName()},
-                                     {"long_name", "Maps every edge to the two node that it connects"}},
+                                     {"long_name", "Maps every edge to the two nodes that it connects"}},
                                     true);
 
         if (mesh1d.edge_edge_offset != nullptr && mesh1d.edge_edge_id)
@@ -161,7 +161,7 @@ void Mesh1D::define(ugridapi::Mesh1D const& mesh1d)
                                         "edge_edge",
                                         netCDF::NcType::nc_INT,
                                         {UGridFileDimensions::edge},
-                                        {{"long_name", "Index of branch on which mesh edge are located"}}, true, true);
+                                        {{"long_name", "Index of branch on which mesh edges are located"}}, true, true);
             // Define edge_offset variable
             define_topological_variable("edge_coordinates",
                                         "edge_edge_offset",

--- a/UGrid/libs/UGrid/src/Mesh1D.cpp
+++ b/UGrid/libs/UGrid/src/Mesh1D.cpp
@@ -90,7 +90,7 @@ void Mesh1D::define(ugridapi::Mesh1D const& mesh1d)
                                     "node_edge",
                                     netCDF::NcType::nc_INT,
                                     {UGridFileDimensions::node},
-                                    {{"long_name", "Index of branch on which mesh node are located"}});
+                                    {{"long_name", "Index of branch on which mesh node are located"}}, true);
 
         // Define node offset variable
         define_topological_variable("node_coordinates",
@@ -146,7 +146,8 @@ void Mesh1D::define(ugridapi::Mesh1D const& mesh1d)
                                     netCDF::NcType::nc_INT,
                                     {UGridFileDimensions::edge, UGridFileDimensions::Two},
                                     {{"cf_role", topology_attribute.getName()},
-                                     {"long_name", "Maps every edge to the two node that it connects"}});
+                                     {"long_name", "Maps every edge to the two node that it connects"}},
+                                    true);
 
         if (mesh1d.edge_edge_offset != nullptr && mesh1d.edge_edge_id)
         {
@@ -160,7 +161,7 @@ void Mesh1D::define(ugridapi::Mesh1D const& mesh1d)
                                         "edge_edge",
                                         netCDF::NcType::nc_INT,
                                         {UGridFileDimensions::edge},
-                                        {{"long_name", "Index of branch on which mesh edge are located"}});
+                                        {{"long_name", "Index of branch on which mesh edge are located"}}, true, true);
             // Define edge_offset variable
             define_topological_variable("edge_coordinates",
                                         "edge_edge_offset",

--- a/UGrid/libs/UGrid/src/Mesh2D.cpp
+++ b/UGrid/libs/UGrid/src/Mesh2D.cpp
@@ -52,7 +52,7 @@ void Mesh2D::define(ugridapi::Mesh2D const& mesh2d)
         throw std::invalid_argument("Mesh2D::define mesh name field is empty");
     }
 
-    UGridEntity::define(mesh2d.name, mesh2d.start_index, "Topology data of 2D mesh", 2, mesh2d.is_spherical);
+    UGridEntity::define(mesh2d.name, mesh2d.start_index, "Topology data of 2D mesh", 2, mesh2d.is_spherical, mesh2d.grid_mapping);
     auto string_builder = UGridVarAttributeStringBuilder(m_entity_name);
 
     // node variables
@@ -74,18 +74,8 @@ void Mesh2D::define(ugridapi::Mesh2D const& mesh2d)
         // Define optional related variables
         if (mesh2d.node_z != nullptr)
         {
-            auto const location_attribute_value = get_location_attribute_value("node");
-            define_topology_related_variables(
-                "node_z",
-                netCDF::NcType::nc_DOUBLE,
-                {UGridFileDimensions::node},
-                {{"mesh", m_entity_name},
-                 {"standard_name", "altitude"},
-                 {"long_name", "z-coordinate of mesh node"},
-                 {"units", "m"},
-                 {"coordinates", location_attribute_value},
-                 {"location", "node"}},
-                true);
+            auto const attributes = create_data_variable_attributes("altitude", "z-coordinate of mesh node", "m", UGridEntityLocations::node);
+            define_topology_related_variables("node_z", netCDF::NcType::nc_DOUBLE, {UGridFileDimensions::node}, attributes, true);
         }
     }
 

--- a/UGrid/libs/UGrid/src/Mesh2D.cpp
+++ b/UGrid/libs/UGrid/src/Mesh2D.cpp
@@ -98,7 +98,7 @@ void Mesh2D::define(ugridapi::Mesh2D const& mesh2d)
                                     "edge_nodes",
                                     netCDF::NcType::nc_INT,
                                     {UGridFileDimensions::edge, UGridFileDimensions::Two},
-                                    {{"long_name", "Start and end node of mesh edge"}});
+                                    {{"long_name", "Start and end node of mesh edge"}}, true);
 
         // Define edge_nodes coordinates
         if (mesh2d.edge_x != nullptr && mesh2d.edge_y != nullptr)
@@ -129,7 +129,7 @@ void Mesh2D::define(ugridapi::Mesh2D const& mesh2d)
                                     "face_nodes",
                                     netCDF::NcType::nc_INT,
                                     {UGridFileDimensions::face, UGridFileDimensions::max_face_node},
-                                    {{"long_name", "Vertex node of mesh face(counterclockwise)"}}, true);
+                                    {{"long_name", "Vertex node of mesh face(counterclockwise)"}}, true, true);
 
         // Define face coordinates
         bool const add_coordinate_variable = mesh2d.face_x != nullptr && mesh2d.face_y != nullptr;
@@ -153,13 +153,13 @@ void Mesh2D::define(ugridapi::Mesh2D const& mesh2d)
         {
             // Define face_edges topology attribute and variable
             string_builder.clear();
-            string_builder << "_face_edge";
+            string_builder << "_face_edges";
             define_topological_attribute("face_edge_connectivity", string_builder.str());
             define_topological_variable("face_edge_connectivity",
-                                        "face_edge",
+                                        "face_edges",
                                         netCDF::NcType::nc_INT,
                                         {UGridFileDimensions::face, UGridFileDimensions::max_face_node},
-                                        {{"long_name", "Side edge of mesh face (counterclockwise)"}}, true);
+                                        {{"long_name", "Side edge of mesh face (counterclockwise)"}}, true, true);
         }
         if (mesh2d.face_faces != nullptr)
         {
@@ -171,7 +171,7 @@ void Mesh2D::define(ugridapi::Mesh2D const& mesh2d)
                                         "face_links",
                                         netCDF::NcType::nc_INT,
                                         {UGridFileDimensions::face, UGridFileDimensions::max_face_node},
-                                        {{"long_name", "Neighboring face of mesh face (counterclockwise)"}});
+                                        {{"long_name", "Neighboring face of mesh face (counterclockwise)"}}, true, true);
         }
         if (mesh2d.edge_faces != nullptr)
         {
@@ -183,7 +183,7 @@ void Mesh2D::define(ugridapi::Mesh2D const& mesh2d)
                                         "edge_faces",
                                         netCDF::NcType::nc_INT,
                                         {UGridFileDimensions::edge, UGridFileDimensions::Two},
-                                        {{"long_name", "Neighboring face of mesh edge"}});
+                                        {{"long_name", "Neighboring face of mesh edge"}}, true, true);
         }
     }
 

--- a/UGrid/libs/UGrid/src/Network1D.cpp
+++ b/UGrid/libs/UGrid/src/Network1D.cpp
@@ -86,7 +86,7 @@ void Network1D::define(ugridapi::Network1D const& network1d)
         throw std::invalid_argument("Network1D::define network geometry coordinates missing");
     }
 
-    UGridEntity::define(network1d.name, network1d.start_index, "Topology data of 1D network", 1, network1d.is_spherical);
+    UGridEntity::define(network1d.name, network1d.start_index, "Topology data of 1D network", 1, network1d.is_spherical, network1d.grid_mapping);
     auto string_builder = UGridVarAttributeStringBuilder(m_entity_name);
 
     // node variables

--- a/UGrid/libs/UGrid/src/Network1D.cpp
+++ b/UGrid/libs/UGrid/src/Network1D.cpp
@@ -140,7 +140,8 @@ void Network1D::define(ugridapi::Network1D const& network1d)
                                     netCDF::NcType::nc_INT,
                                     {UGridFileDimensions::edge, UGridFileDimensions::Two},
                                     {{"cf_role", "edge_node_connectivity"},
-                                     {"long_name", "Start and end node of network edge"}});
+                                     {"long_name", "Start and end node of network edge"}},
+                                    true);
 
         // Define edge_lengths topology attribute and variable
         define_topological_attribute("edge_length");

--- a/UGrid/libs/UGrid/src/UGridEntity.cpp
+++ b/UGrid/libs/UGrid/src/UGridEntity.cpp
@@ -93,22 +93,44 @@ bool UGridEntity::has_matching_dimensionality(std::map<std::string, netCDF::NcVa
     return false;
 }
 
-std::string UGridEntity::get_location_attribute_value(std::string const& location)
+std::vector<std::pair<std::string, std::string>> UGridEntity::create_coordinate_variable_attributes(
+    std::string const& units,
+    std::string const& standard_name,
+    std::string const& long_name)
 {
+    std::vector<std::pair<std::string, std::string>> attributes = {{"units", units},
+                                                                   {"standard_name", standard_name},
+                                                                   {"long_name", long_name}};
+    if (!m_grid_mapping.empty())
+    {
+        attributes.emplace_back("grid_mapping", m_grid_mapping);
+    }
+    return attributes;
+}
+
+std::vector<std::pair<std::string, std::string>> UGridEntity::create_data_variable_attributes(
+    std::string const& standard_name,
+    std::string const& long_name,
+    std::string const& units,
+    UGridEntityLocations location)
+{
+    std::string const location_str = from_location_to_location_string(location);
+
     UGridVarAttributeStringBuilder string_builder(m_entity_name);
-    if (!m_spherical_coordinates)
-    {
-        string_builder.clear();
-        string_builder << "_" << location << "_x " << m_entity_name << "_" << location << "_y";
-    }
+    string_builder << "_" << location_str << "_x " << m_entity_name << "_" << location_str << "_y";
+    std::string const coordinates = string_builder.str();
 
-    if (m_spherical_coordinates)
+    std::vector<std::pair<std::string, std::string>> attributes = {{"mesh", m_entity_name},
+                                                                   {"standard_name", standard_name},
+                                                                   {"long_name", long_name},
+                                                                   {"units", units},
+                                                                   {"coordinates", coordinates},
+                                                                   {"location", location_str}};
+    if (!m_grid_mapping.empty())
     {
-        string_builder.clear();
-        string_builder << "_" << location << "_lon " << m_entity_name << "_" << location << "_lat";
+        attributes.emplace_back("grid_mapping", m_grid_mapping);
     }
-
-    return string_builder.str();
+    return attributes;
 }
 
 std::vector<std::string> UGridEntity::get_data_variables_names(std::string const& location_string)
@@ -152,8 +174,6 @@ std::tuple<std::string,
            std::string>
 UGridEntity::get_location_variable_names(UGridEntityLocations location, std::string const& long_name_pattern, std::string const& name_pattern)
 {
-    std::string location_coordinate_x;
-    std::string location_coordinate_y;
     std::string standard_name_x;
     std::string standard_name_y;
     std::string long_name_x;
@@ -162,12 +182,11 @@ UGridEntity::get_location_variable_names(UGridEntityLocations location, std::str
     std::string units_y;
 
     std::string const location_str = from_location_to_location_string(location);
+    std::string const location_coordinate_x = std::vformat(name_pattern, std::make_format_args(location_str, "_x"));
+    std::string const location_coordinate_y = std::vformat(name_pattern, std::make_format_args(location_str, "_y"));
 
     if (!m_spherical_coordinates)
     {
-        location_coordinate_x = std::vformat(name_pattern, std::make_format_args(location_str, "_x"));
-        location_coordinate_y = std::vformat(name_pattern, std::make_format_args(location_str, "_y"));
-
         long_name_x = std::vformat(long_name_pattern, std::make_format_args("x-coordinate"));
         long_name_y = std::vformat(long_name_pattern, std::make_format_args("y-coordinate"));
 
@@ -179,17 +198,14 @@ UGridEntity::get_location_variable_names(UGridEntityLocations location, std::str
     }
     if (m_spherical_coordinates)
     {
-        location_coordinate_x = std::vformat(name_pattern, std::make_format_args(location_str, "_lon"));
-        location_coordinate_y = std::vformat(name_pattern, std::make_format_args(location_str, "_lat"));
+        long_name_x = std::vformat(long_name_pattern, std::make_format_args("longitude coordinate"));
+        long_name_y = std::vformat(long_name_pattern, std::make_format_args("latitude coordinate"));
 
-        long_name_x = std::vformat(long_name_pattern, std::make_format_args("latitude coordinate"));
-        long_name_y = std::vformat(long_name_pattern, std::make_format_args("longitude coordinate"));
+        standard_name_x = "longitude";
+        standard_name_y = "latitude";
 
-        standard_name_x = "latitude";
-        standard_name_y = "longitude";
-
-        units_x = "degrees_north";
-        units_y = "degrees_east";
+        units_x = "degrees_east";
+        units_y = "degrees_north";
     }
 
     return {location_coordinate_x, location_coordinate_y, standard_name_x, standard_name_y, long_name_x, long_name_y, units_x, units_y};
@@ -212,23 +228,23 @@ void UGridEntity::define_topology_coordinates(UGridEntityLocations location, std
     std::string const attribute_name = from_location_to_location_string(location) + "_coordinates";
     define_topological_attribute(attribute_name, string_builder.str());
 
-    UGridFileDimensions const dimension = from_location_to_dimension(location);
+    auto const dimension = from_location_to_dimension(location);
+    auto const attributes_x = create_coordinate_variable_attributes(units_x, standard_name_x, long_name_x);
+    auto const attributes_y = create_coordinate_variable_attributes(units_y, standard_name_y, long_name_y);
 
-    define_topological_variable(attribute_name,
-                                location_coordinate_x,
-                                netCDF::NcType::nc_DOUBLE,
-                                {dimension},
-                                {{"units", units_x},
-                                 {"standard_name", standard_name_x},
-                                 {"long_name", long_name_x}});
+    define_topological_variable(
+        attribute_name,
+        location_coordinate_x,
+        netCDF::NcType::nc_DOUBLE,
+        {dimension},
+        attributes_x);
 
-    define_topological_variable(attribute_name,
-                                location_coordinate_y,
-                                netCDF::NcType::nc_DOUBLE,
-                                {dimension},
-                                {{"units", units_y},
-                                 {"standard_name", standard_name_y},
-                                 {"long_name", long_name_y}});
+    define_topological_variable(
+        attribute_name,
+        location_coordinate_y,
+        netCDF::NcType::nc_DOUBLE,
+        {dimension},
+        attributes_y);
 }
 
 void UGridEntity::define_topology_related_coordinates(
@@ -243,11 +259,11 @@ void UGridEntity::define_topology_related_coordinates(
         {UGridFileDimensions::face, UGridFileDimensions::max_face_node}};
 
     UGridFileDimensions const dimension = from_location_to_dimension(location);
-    std::vector<UGridFileDimensions> ugridfile_dimensions = {dimension};
+    std::vector<UGridFileDimensions> dimensions = {dimension};
 
     if (auto const it = extra_dimension.find(dimension); it != extra_dimension.end())
     {
-        ugridfile_dimensions.emplace_back(it->second);
+        dimensions.emplace_back(it->second);
     }
 
     auto [location_coordinate_x,
@@ -266,15 +282,6 @@ void UGridEntity::define_topology_related_coordinates(
         m_topology_attribute_variables.at(topology_attribute_name).at(0).putAtt(attribute_name, string_builder.str());
     }
 
-    define_topology_related_variables(
-        location_coordinate_x,
-        netCDF::NcType::nc_DOUBLE,
-        ugridfile_dimensions,
-        {{"units", units_x},
-         {"standard_name", standard_name_x},
-         {"long_name", long_name_x}},
-        true);
-
     if (!topology_attribute_name.empty() && !attribute_name.empty())
     {
         auto string_builder = UGridVarAttributeStringBuilder(m_entity_name);
@@ -282,13 +289,21 @@ void UGridEntity::define_topology_related_coordinates(
         m_topology_attribute_variables.at(topology_attribute_name).at(1).putAtt(attribute_name, string_builder.str());
     }
 
+    auto const attributes_x = create_coordinate_variable_attributes(units_x, standard_name_x, long_name_x);
+    auto const attributes_y = create_coordinate_variable_attributes(units_y, standard_name_y, long_name_y);
+
+    define_topology_related_variables(
+        location_coordinate_x,
+        netCDF::NcType::nc_DOUBLE,
+        dimensions,
+        attributes_x,
+        true);
+
     define_topology_related_variables(
         location_coordinate_y,
         netCDF::NcType::nc_DOUBLE,
-        ugridfile_dimensions,
-        {{"units", units_y},
-         {"standard_name", standard_name_y},
-         {"long_name", long_name_y}},
+        dimensions,
+        attributes_y,
         true);
 }
 
@@ -411,10 +426,12 @@ void UGridEntity::define(char const* const entity_name,
                          int start_index,
                          std::string const& long_name,
                          int topology_dimension,
-                         int is_spherical)
+                         int is_spherical,
+                         char const* const grid_mapping)
 {
     m_start_index = start_index;
     m_entity_name = char_array_to_string(entity_name, name_length);
+    m_grid_mapping = char_array_to_string(grid_mapping, name_long_length);
     m_spherical_coordinates = is_spherical == 0 ? false : true;
 
     // Topology name

--- a/UGrid/libs/UGrid/src/UGridEntity.cpp
+++ b/UGrid/libs/UGrid/src/UGridEntity.cpp
@@ -343,6 +343,7 @@ void UGridEntity::define_topological_variable(std::string const& topology_attrib
                                               netCDF::NcType nc_type,
                                               std::vector<UGridFileDimensions> const& ugridfile_dimensions,
                                               std::vector<std::pair<std::string, std::string>> const& attributes,
+                                              bool add_start_index,
                                               bool add_fill_value)
 {
     auto string_builder = UGridVarAttributeStringBuilder(m_entity_name);
@@ -364,8 +365,8 @@ void UGridEntity::define_topological_variable(std::string const& topology_attrib
         topology_attribute_variable.putAtt(attribute.first, attribute.second);
     }
 
-    // add start index if necessary
-    if (m_start_index != 0)
+    // add start index
+    if (add_start_index)
     {
         topology_attribute_variable.putAtt("start_index", netCDF::NcType::nc_INT, m_start_index);
     }
@@ -435,7 +436,7 @@ void UGridEntity::define(char const* const entity_name,
     m_spherical_coordinates = is_spherical == 0 ? false : true;
 
     // Topology name
-    m_topology_variable = m_nc_file->addVar(m_entity_name, netCDF::NcType::nc_CHAR);
+    m_topology_variable = m_nc_file->addVar(m_entity_name, netCDF::NcType::nc_INT);
 
     // Topology attributes
     define_topological_attribute("cf_role", "mesh_topology");

--- a/UGrid/libs/UGridAPI/include/UGridAPI/Mesh1D.hpp
+++ b/UGrid/libs/UGridAPI/include/UGridAPI/Mesh1D.hpp
@@ -82,6 +82,9 @@ namespace ugridapi
         /// @brief 1 If coordinates are in a spherical system, 0 otherwise
         int is_spherical = 0;
 
+        /// @brief The name of the variable that defines the coordinate system
+        char* grid_mapping = nullptr;
+
         /// @brief The start index used in arrays using indices, such as edge_node
         int start_index = 0;
 

--- a/UGrid/libs/UGridAPI/include/UGridAPI/Mesh2D.hpp
+++ b/UGrid/libs/UGridAPI/include/UGridAPI/Mesh2D.hpp
@@ -112,6 +112,9 @@ namespace ugridapi
         /// @brief 1 if coordinates are in a spherical system, 0 otherwise
         int is_spherical = 0;
 
+        /// @brief The name of the variable that defines the coordinate system
+        char* grid_mapping = nullptr;
+
         /// @brief The fill value for array of doubles
         double double_fill_value = ugrid::double_missing_value;
 

--- a/UGrid/libs/UGridAPI/include/UGridAPI/Network1D.hpp
+++ b/UGrid/libs/UGridAPI/include/UGridAPI/Network1D.hpp
@@ -83,6 +83,9 @@ namespace ugridapi
         /// @brief 1 If the coordinates are in a spherical system, 0 otherwise
         int is_spherical = 0;
 
+        /// @brief The name of the variable that defines the coordinate system
+        char* grid_mapping = nullptr;
+
         /// @brief The start index used in arrays using indices, such as in the edge_node array
         int start_index = 0;
     };

--- a/UGridNET/UGridNET.Tests/DisposableMesh1DTests.cs
+++ b/UGridNET/UGridNET.Tests/DisposableMesh1DTests.cs
@@ -1,0 +1,64 @@
+﻿using NUnit.Framework;
+using UGridNET.Extensions;
+
+namespace UGridNET.Tests
+{
+    [TestFixture]
+    public class DisposableMesh1DTests
+    {
+        [Test]
+        public void CreateNativeObject_WithPopulatedDisposableMesh1D_ReturnsMesh1DWithCorrectValues()
+        {
+            const int numNodes = 3;
+            const int numEdges = 2;
+
+            const string name = "myMesh1D";
+            const string networkName = "myNetwork";
+            const string gridMapping = "wgs84";
+
+            var nodeX = new[] { 1.0, 2.0, 3.0 };
+            var nodeY = new[] { 4.0, 5.0, 6.0 };
+            var nodeEdgeID = new[] { 0, 1, 2 };
+            var nodeEdgeOffset = new[] { 0.1, 0.2, 0.3 };
+            var edgeX = new[] { 1.5, 2.5 };
+            var edgeY = new[] { 4.5, 5.5 };
+            var edgeNodes = new[] { 0, 1, 1, 2 };
+
+            var disposableMesh1D = new DisposableMesh1D
+            {
+                NumNodes = numNodes,
+                NumEdges = numEdges,
+                IsSpherical = true,
+                Name = name.GetRightPaddedNullTerminatedBytes(UGrid.name_long_length),
+                NetworkName = networkName.GetRightPaddedNullTerminatedBytes(UGrid.name_long_length),
+                GridMapping = gridMapping.GetRightPaddedNullTerminatedBytes(UGrid.name_long_length),
+                NodeX = nodeX,
+                NodeY = nodeY,
+                NodeEdgeID = nodeEdgeID,
+                NodeEdgeOffset = nodeEdgeOffset,
+                EdgeX = edgeX,
+                EdgeY = edgeY,
+                EdgeNodes = edgeNodes
+            };
+
+            using (disposableMesh1D)
+            {
+                Mesh1D nativeMesh1D = disposableMesh1D.CreateNativeObject();
+
+                Assert.That(nativeMesh1D.num_nodes, Is.EqualTo(numNodes));
+                Assert.That(nativeMesh1D.num_edges, Is.EqualTo(numEdges));
+                Assert.That(nativeMesh1D.is_spherical, Is.EqualTo(1));
+                Assert.That(nativeMesh1D.name.CopyToArray<byte>(UGrid.name_long_length).GetStringFromNullTerminatedArray(true), Is.EqualTo(name));
+                Assert.That(nativeMesh1D.network_name.CopyToArray<byte>(UGrid.name_long_length).GetStringFromNullTerminatedArray(true), Is.EqualTo(networkName));
+                Assert.That(nativeMesh1D.grid_mapping.CopyToArray<byte>(UGrid.name_long_length).GetStringFromNullTerminatedArray(true), Is.EqualTo(gridMapping));
+                Assert.That(nativeMesh1D.node_x.CopyToArray<double>(numNodes), Is.EqualTo(nodeX));
+                Assert.That(nativeMesh1D.node_y.CopyToArray<double>(numNodes), Is.EqualTo(nodeY));
+                Assert.That(nativeMesh1D.node_edge_id.CopyToArray<int>(numNodes), Is.EqualTo(nodeEdgeID));
+                Assert.That(nativeMesh1D.node_edge_offset.CopyToArray<double>(numNodes), Is.EqualTo(nodeEdgeOffset));
+                Assert.That(nativeMesh1D.edge_x.CopyToArray<double>(numEdges), Is.EqualTo(edgeX));
+                Assert.That(nativeMesh1D.edge_y.CopyToArray<double>(numEdges), Is.EqualTo(edgeY));
+                Assert.That(nativeMesh1D.edge_nodes.CopyToArray<int>(numEdges * 2), Is.EqualTo(edgeNodes));
+            }
+        }
+    }
+}

--- a/UGridNET/UGridNET.Tests/DisposableMesh2DTests.cs
+++ b/UGridNET/UGridNET.Tests/DisposableMesh2DTests.cs
@@ -1,0 +1,94 @@
+﻿using NUnit.Framework;
+using UGridNET.Extensions;
+
+namespace UGridNET.Tests
+{
+    [TestFixture]
+    public class DisposableMesh2DTests
+    {
+        [Test]
+        public void CreateNativeObject_WithPopulatedDisposableMesh2D_ReturnsMesh2DWithCorrectValues()
+        {
+            const int numNodes = 4;
+            const int numEdges = 4;
+            const int numFaces = 1;
+            const int numFaceNodesMax = 4;
+
+            const string name = "myMesh2D";
+            const string gridMapping = "projected_coordinate_system";
+
+            var nodeX = new[] { 0.0, 1.0, 1.0, 0.0 };
+            var nodeY = new[] { 0.0, 0.0, 1.0, 1.0 };
+            var nodeZ = new[] { 0.0, 0.0, 0.0, 0.0 };
+            var edgeX = new[] { 0.5, 1.0, 0.5, 0.0 };
+            var edgeY = new[] { 0.0, 0.5, 1.0, 0.5 };
+            var edgeZ = new[] { 0.0, 0.0, 0.0, 0.0 };
+            var edgeNodes = new[] { 0, 1, 1, 2, 2, 3, 3, 0 };
+            var edgeFaces = new[] { 0, 0, 0, 0, 0, 0, 0, 0 };
+            var faceX = new[] { 0.5 };
+            var faceY = new[] { 0.5 };
+            var faceZ = new[] { 0.0 };
+            var faceBoundsX = new[] { 0.0, 1.0, 1.0, 0.0 };
+            var faceBoundsY = new[] { 0.0, 0.0, 1.0, 1.0 };
+            var faceNodes = new[] { 0, 1, 2, 3 };
+            var faceEdges = new[] { 0, 1, 2, 3 };
+            int[] faceFaces = { -1, -1, -1, -1 };
+
+            var disposableMesh2D = new DisposableMesh2D
+            {
+                NumNodes = numNodes,
+                NumEdges = numEdges,
+                NumFaces = numFaces,
+                NumFaceNodesMax = numFaceNodesMax,
+                IsSpherical = true,
+                Name = name.GetRightPaddedNullTerminatedBytes(UGrid.name_long_length),
+                GridMapping = gridMapping.GetRightPaddedNullTerminatedBytes(UGrid.name_long_length),
+                NodeX = nodeX,
+                NodeY = nodeY,
+                NodeZ = nodeZ,
+                EdgeX = edgeX,
+                EdgeY = edgeY,
+                EdgeZ = edgeZ,
+                EdgeNodes = edgeNodes,
+                EdgeFaces = edgeFaces,
+                FaceX = faceX,
+                FaceY = faceY,
+                FaceZ = faceZ,
+                FaceBoundsX = faceBoundsX,
+                FaceBoundsY = faceBoundsY,
+                FaceNodes = faceNodes,
+                FaceEdges = faceEdges,
+                FaceFaces = faceFaces
+            };
+
+            using (disposableMesh2D)
+            {
+                Mesh2D nativeMesh2D = disposableMesh2D.CreateNativeObject();
+
+                Assert.That(nativeMesh2D.num_nodes, Is.EqualTo(numNodes));
+                Assert.That(nativeMesh2D.num_edges, Is.EqualTo(numEdges));
+                Assert.That(nativeMesh2D.num_faces, Is.EqualTo(numFaces));
+                Assert.That(nativeMesh2D.num_face_nodes_max, Is.EqualTo(numFaceNodesMax));
+                Assert.That(nativeMesh2D.is_spherical, Is.EqualTo(1));
+                Assert.That(nativeMesh2D.name.CopyToArray<byte>(UGrid.name_long_length).GetStringFromNullTerminatedArray(true), Is.EqualTo(name));
+                Assert.That(nativeMesh2D.grid_mapping.CopyToArray<byte>(UGrid.name_long_length).GetStringFromNullTerminatedArray(true), Is.EqualTo(gridMapping));
+                Assert.That(nativeMesh2D.node_x.CopyToArray<double>(numNodes), Is.EqualTo(nodeX));
+                Assert.That(nativeMesh2D.node_y.CopyToArray<double>(numNodes), Is.EqualTo(nodeY));
+                Assert.That(nativeMesh2D.node_z.CopyToArray<double>(numNodes), Is.EqualTo(nodeZ));
+                Assert.That(nativeMesh2D.edge_x.CopyToArray<double>(numEdges), Is.EqualTo(edgeX));
+                Assert.That(nativeMesh2D.edge_y.CopyToArray<double>(numEdges), Is.EqualTo(edgeY));
+                Assert.That(nativeMesh2D.edge_z.CopyToArray<double>(numEdges), Is.EqualTo(edgeZ));
+                Assert.That(nativeMesh2D.edge_nodes.CopyToArray<int>(numEdges * 2), Is.EqualTo(edgeNodes));
+                Assert.That(nativeMesh2D.edge_faces.CopyToArray<int>(numEdges * 2), Is.EqualTo(edgeFaces));
+                Assert.That(nativeMesh2D.face_x.CopyToArray<double>(numFaces), Is.EqualTo(faceX));
+                Assert.That(nativeMesh2D.face_y.CopyToArray<double>(numFaces), Is.EqualTo(faceY));
+                Assert.That(nativeMesh2D.face_z.CopyToArray<double>(numFaces), Is.EqualTo(faceZ));
+                Assert.That(nativeMesh2D.face_x_bnd.CopyToArray<double>(numFaces * numFaceNodesMax), Is.EqualTo(faceBoundsX));
+                Assert.That(nativeMesh2D.face_y_bnd.CopyToArray<double>(numFaces * numFaceNodesMax), Is.EqualTo(faceBoundsY));
+                Assert.That(nativeMesh2D.face_nodes.CopyToArray<int>(numFaces * numFaceNodesMax), Is.EqualTo(faceNodes));
+                Assert.That(nativeMesh2D.face_edges.CopyToArray<int>(numFaces * numFaceNodesMax), Is.EqualTo(faceEdges));
+                Assert.That(nativeMesh2D.face_faces.CopyToArray<int>(numFaces * numFaceNodesMax), Is.EqualTo(faceFaces));
+            }
+        }
+    }
+}

--- a/UGridNET/UGridNET.Tests/UGridWriterTests.cs
+++ b/UGridNET/UGridNET.Tests/UGridWriterTests.cs
@@ -51,13 +51,13 @@ namespace UGridNET.Tests
             UGridWriter file = null;
 
             DisposableMesh1D disposableMesh1D = CreateDisposableMesh1D("myMesh1D", "myNetwork");
-            ProjectedCoordinateSystem projectedCoordinateSystem = CreateCoordinateSystem();
+            CoordinateSystem coordinateSystem = CreateCoordinateSystem();
 
             try
             {
                 Assert.DoesNotThrow(() => file = new UGridWriter(filePath));
                 Assert.DoesNotThrow(() => file.AddMesh1D(disposableMesh1D));
-                Assert.DoesNotThrow(() => file.AddProjectedCoordinateSystem(projectedCoordinateSystem));
+                Assert.DoesNotThrow(() => file.AddCoordinateSystem(coordinateSystem));
                 Assert.DoesNotThrow(() => file.AddGlobalAttribute("source", "Unit test"));
                 Assert.DoesNotThrow(() => file.AddGlobalAttributes(globalAttributes));
                 Assert.DoesNotThrow(() => file.WriteTopologies());
@@ -79,13 +79,13 @@ namespace UGridNET.Tests
             UGridWriter file = null;
 
             DisposableMesh2D disposableMesh2D = CreateDisposableMesh2D("myMesh2D");
-            ProjectedCoordinateSystem projectedCoordinateSystem = CreateCoordinateSystem();
+            CoordinateSystem coordinateSystem = CreateCoordinateSystem();
 
             try
             {
                 Assert.DoesNotThrow(() => file = new UGridWriter(filePath));
                 Assert.DoesNotThrow(() => file.AddMesh2D(disposableMesh2D));
-                Assert.DoesNotThrow(() => file.AddProjectedCoordinateSystem(projectedCoordinateSystem));
+                Assert.DoesNotThrow(() => file.AddCoordinateSystem(coordinateSystem));
                 Assert.DoesNotThrow(() => file.AddGlobalAttribute("source", "Unit test"));
                 Assert.DoesNotThrow(() => file.AddGlobalAttributes(globalAttributes));
                 Assert.DoesNotThrow(() => file.WriteTopologies());
@@ -143,20 +143,48 @@ namespace UGridNET.Tests
 
         [Test]
         [Order(3)]
-        public void WritingMesh2DWGS84_ShouldWriteFile()
+        public void WritingMesh2D_WGS84_ShouldWriteFile()
         {
-            string filePath = Path.Combine(testOutputDir, "mesh2DWGS84.nc");
+            string filePath = Path.Combine(testOutputDir, "mesh2D_WGS84.nc");
 
             UGridWriter file = null;
 
-            DisposableMesh2D disposableMesh2D = CreateDisposableMesh2D("mesh2DWGS84");
-            ProjectedCoordinateSystem projectedCoordinateSystem = CreateGeographicCoordinateSystem();
+            DisposableMesh2D disposableMesh2D = CreateDisposableMesh2D("mesh2D_WGS84", true);
+            CoordinateSystem coordinateSystem = CreateGeographicCoordinateSystem();
 
             try
             {
                 Assert.DoesNotThrow(() => file = new UGridWriter(filePath));
                 Assert.DoesNotThrow(() => file.AddMesh2D(disposableMesh2D));
-                Assert.DoesNotThrow(() => file.AddProjectedCoordinateSystem(projectedCoordinateSystem));
+                Assert.DoesNotThrow(() => file.AddCoordinateSystem(coordinateSystem));
+                Assert.DoesNotThrow(() => file.AddGlobalAttribute("source", "Unit test"));
+                Assert.DoesNotThrow(() => file.AddGlobalAttributes(globalAttributes));
+                Assert.DoesNotThrow(() => file.WriteTopologies());
+                Assert.That(file.HasMesh2D, Is.True);
+                Assert.That(file.Mesh2DList.Count, Is.EqualTo(1));
+            }
+            finally
+            {
+                file?.Dispose();
+            }
+        }
+        
+        [Test]
+        [Order(4)]
+        public void WritingMesh2D_AmersfoortRdNew_ShouldWriteFile()
+        {
+            string filePath = Path.Combine(testOutputDir, "mesh2D_Amersfoort.nc");
+
+            UGridWriter file = null;
+
+            DisposableMesh2D disposableMesh2D = CreateDisposableMesh2D("mesh2D_Amersfoort");
+            CoordinateSystem coordinateSystem = CreateProjectedCoordinateSystem();
+
+            try
+            {
+                Assert.DoesNotThrow(() => file = new UGridWriter(filePath));
+                Assert.DoesNotThrow(() => file.AddMesh2D(disposableMesh2D));
+                Assert.DoesNotThrow(() => file.AddCoordinateSystem(coordinateSystem));
                 Assert.DoesNotThrow(() => file.AddGlobalAttribute("source", "Unit test"));
                 Assert.DoesNotThrow(() => file.AddGlobalAttributes(globalAttributes));
                 Assert.DoesNotThrow(() => file.WriteTopologies());
@@ -170,10 +198,10 @@ namespace UGridNET.Tests
         }
 
         [Test]
-        [Order(4)]
-        public void ImportingExportedMesh2DWGS84_GetsCorrectEPSGCode()
+        [Order(5)]
+        public void ImportingExportedMesh2D_WGS84_GetsCorrectEPSGCode()
         {
-            string filePath = Path.Combine(testOutputDir, "mesh2DWGS84.nc");
+            string filePath = Path.Combine(testOutputDir, "mesh2D_WGS84.nc");
             UGridReader file = null;
             try
             {
@@ -188,12 +216,33 @@ namespace UGridNET.Tests
                 file?.Dispose();
             }
         }
+
+        [Test]
+        [Order(6)]
+        public void ImportingExportedMesh2D_Amersfoort_GetsCorrectEPSGCode()
+        {
+            string filePath = Path.Combine(testOutputDir, "mesh2D_Amersfoort.nc");
+            UGridReader file = null;
+            try
+            {
+                file = new UGridReader(filePath);
+
+                Assert.That(file.HasMesh2D, Is.True);
+                Assert.That(file.GetEPSGCode(), Is.EqualTo(28992));
+                Assert.That(file.Mesh2DList.Count, Is.EqualTo(1));
+            }
+            finally
+            {
+                file?.Dispose();
+            }
+        }
         
-        private static DisposableMesh2D CreateDisposableMesh2D(string meshName)
+        private static DisposableMesh2D CreateDisposableMesh2D(string meshName, bool spherical = false)
         {
             return new DisposableMesh2D
             {
                 Name = meshName.GetRightPaddedNullTerminatedBytes(UGrid.name_long_length),
+                IsSpherical = spherical,
                 NumNodes = 4,
                 NumEdges = 4,
                 NumFaces = 1,
@@ -238,46 +287,52 @@ namespace UGridNET.Tests
             };
         }
 
-        private static ProjectedCoordinateSystem CreateCoordinateSystem()
+        private static CoordinateSystem CreateCoordinateSystem()
         {
-            string wktStr =
-                "POINT (30 10)\n" + 
-                "LINESTRING (30 10, 10 30, 40 40)\n" + 
-                "POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))\n" + 
-                "MULTIPOINT ((10 40), (40 30), (20 20), (30 10))\n" + 
-                "GEOMETRYCOLLECTION (\n" + 
-                "    POINT (10 40),\n" + 
-                "    LINESTRING (30 10, 10 30, 40 40),\n" + 
-                "    POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))\n" + ')';
-
-            return new ProjectedCoordinateSystem(
-                0,
-                0.0,
-                6378137.0,
-                6356752.314245,
-                298.257223563,
-                "proj_coord_sys_name",
-                "gridMappingName",
-                "proj4Params",
-                "EPSG:0",
-                "",
-                wktStr);
+            return new CoordinateSystem
+            {
+                Name = "Unknown projected",
+                VariableName = "projected_coordinate_system",
+                EPSG = 0,
+                GridMappingName = "Unknown projected",
+                LongitudeOfPrimeMeridian = 0.0,
+                SemiMajorAxis = 6378137.0,
+                SemiMinorAxis = 6356752.314245,
+                InverseFlattening = 298.257223563,
+                EPSGCode = "EPSG:0"
+            };
         }
 
-        private static ProjectedCoordinateSystem CreateGeographicCoordinateSystem()
+        private static CoordinateSystem CreateGeographicCoordinateSystem()
         {
-            return new ProjectedCoordinateSystem(
-                4326,
-                0.0,
-                6378137.0,
-                6356752.314245,
-                298.257223563,
-                "WGS84",
-                "latitude_longitude",
-                "proj4Params",
-                "EPSG:4326",
-                "",
-                "");
+            return new CoordinateSystem
+            {
+                Name = "WGS84",
+                VariableName = "wgs84",
+                EPSG = 4326,
+                GridMappingName = "latitude_longitude",
+                LongitudeOfPrimeMeridian = 0.0,
+                SemiMajorAxis = 6378137.0,
+                SemiMinorAxis = 6356752.314245,
+                InverseFlattening = 298.257223563,
+                EPSGCode = "EPSG:4326"
+            };
+        }
+
+        private static CoordinateSystem CreateProjectedCoordinateSystem()
+        {
+            return new CoordinateSystem
+            {
+                Name = "Amersfoort / RD New",
+                VariableName = "projected_coordinate_system",
+                EPSG = 28992,
+                GridMappingName = "Unknown projected",
+                LongitudeOfPrimeMeridian = 0.0,
+                SemiMajorAxis = 6378137.0,
+                SemiMinorAxis = 6356752.31424518,
+                InverseFlattening = 298.1528128,
+                EPSGCode = "EPSG:28992"
+            };
         }
     }
 }

--- a/UGridNET/UGridNET/CoordinateSystem.cs
+++ b/UGridNET/UGridNET/CoordinateSystem.cs
@@ -1,0 +1,58 @@
+namespace UGridNET
+{
+    /// <summary>
+    /// Represents a coordinate system.
+    /// </summary>
+    public sealed class CoordinateSystem
+    {
+        /// <summary>
+        /// Gets or sets the coordinate system name.
+        /// </summary>
+        public string Name { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the variable name.
+        /// </summary>
+        public string VariableName { get; set; }
+        
+        /// <summary>
+        /// Gets or sets whether this is a spherical coordinate system.
+        /// </summary>
+        public bool IsSpherical { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the EPSG code.
+        /// </summary>
+        public int EPSG { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the grid mapping name.
+        /// </summary>
+        public string GridMappingName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the longitude of the prime meridian.
+        /// </summary>
+        public double LongitudeOfPrimeMeridian { get; set; }
+
+        /// <summary>
+        /// Gets or sets the semi-major axis.
+        /// </summary>
+        public double SemiMajorAxis { get; set; }
+
+        /// <summary>
+        /// Gets or sets the semi-minor axis.
+        /// </summary>
+        public double SemiMinorAxis { get; set; }
+
+        /// <summary>
+        /// Gets or sets the inverse flattening.
+        /// </summary>
+        public double InverseFlattening { get; set; }
+
+        /// <summary>
+        /// Gets or sets the EPSG code as a string.
+        /// </summary>
+        public string EPSGCode { get; set; }
+    }
+}

--- a/UGridNET/UGridNET/DisposableMesh1D.cs
+++ b/UGridNET/UGridNET/DisposableMesh1D.cs
@@ -4,6 +4,8 @@ namespace UGridNET
     {
         private byte[] name;
         private byte[] networkName;
+        private byte[] gridMapping;
+        private bool isSpherical;
         private int numNodes;
         private int numEdges;
         private double[] nodeX;
@@ -51,6 +53,18 @@ namespace UGridNET
         {
             get => networkName;
             set => networkName = value;
+        }
+
+        public byte[] GridMapping
+        {
+            get => gridMapping;
+            set => gridMapping = value;
+        }
+        
+        public bool IsSpherical
+        {
+            get => isSpherical;
+            set => isSpherical = value;
         }
 
         public int NumNodes
@@ -107,22 +121,25 @@ namespace UGridNET
             set => edgeNodes = value;
         }
 
-        protected override void SetNativeObject(ref Mesh1D mesh2D)
+        protected override void SetNativeObject(ref Mesh1D mesh1D)
         {
-            mesh2D.name = GetPinnedObjectPointer(Name);
-            mesh2D.network_name = GetPinnedObjectPointer(NetworkName);
+            mesh1D.name = GetPinnedObjectPointer(Name);
+            mesh1D.network_name = GetPinnedObjectPointer(NetworkName);
+            mesh1D.grid_mapping = GetPinnedObjectPointer(GridMapping);
+            
+            mesh1D.is_spherical = IsSpherical ? 1 : 0;
 
-            mesh2D.num_nodes = NumNodes;
-            mesh2D.num_edges = NumEdges;
+            mesh1D.num_nodes = NumNodes;
+            mesh1D.num_edges = NumEdges;
 
-            mesh2D.node_x = GetPinnedObjectPointer(NodeX);
-            mesh2D.node_y = GetPinnedObjectPointer(NodeY);
-            mesh2D.node_edge_id = GetPinnedObjectPointer(NodeEdgeID);
-            mesh2D.node_edge_offset = GetPinnedObjectPointer(NodeEdgeOffset);
+            mesh1D.node_x = GetPinnedObjectPointer(NodeX);
+            mesh1D.node_y = GetPinnedObjectPointer(NodeY);
+            mesh1D.node_edge_id = GetPinnedObjectPointer(NodeEdgeID);
+            mesh1D.node_edge_offset = GetPinnedObjectPointer(NodeEdgeOffset);
 
-            mesh2D.edge_x = GetPinnedObjectPointer(EdgeX);
-            mesh2D.edge_y = GetPinnedObjectPointer(EdgeY);
-            mesh2D.edge_nodes = GetPinnedObjectPointer(EdgeNodes);
+            mesh1D.edge_x = GetPinnedObjectPointer(EdgeX);
+            mesh1D.edge_y = GetPinnedObjectPointer(EdgeY);
+            mesh1D.edge_nodes = GetPinnedObjectPointer(EdgeNodes);
         }
     }
 }

--- a/UGridNET/UGridNET/DisposableMesh2D.cs
+++ b/UGridNET/UGridNET/DisposableMesh2D.cs
@@ -3,6 +3,8 @@ namespace UGridNET
     public sealed class DisposableMesh2D : DisposableNativeObject<Mesh2D>
     {
         private byte[] name;
+        private byte[] gridMapping;
+        private bool isSpherical;
         private int numNodes;
         private int numEdges;
         private int numFaces;
@@ -67,6 +69,18 @@ namespace UGridNET
         {
             get => name;
             set => name = value;
+        }
+
+        public bool IsSpherical
+        {
+            get => isSpherical;
+            set => isSpherical = value;
+        }
+        
+        public byte[] GridMapping
+        {
+            get => gridMapping;
+            set => gridMapping = value;
         }
 
         public int NumNodes
@@ -192,7 +206,9 @@ namespace UGridNET
         protected override void SetNativeObject(ref Mesh2D mesh2D)
         {
             mesh2D.name = GetPinnedObjectPointer(Name);
-
+            mesh2D.grid_mapping = GetPinnedObjectPointer(GridMapping);
+            mesh2D.is_spherical = IsSpherical ? 1 : 0;
+            
             mesh2D.num_nodes = NumNodes;
             mesh2D.num_edges = NumEdges;
             mesh2D.num_faces = NumFaces;

--- a/UGridNET/UGridNET/DisposableNativeObject.cs
+++ b/UGridNET/UGridNET/DisposableNativeObject.cs
@@ -53,8 +53,8 @@ namespace UGridNET
         /// <summary>
         /// Maps the <typeparamref name="TNative"/> object with current state (used in <see cref="CreateNativeObject"/>)
         /// </summary>
-        /// <param name="nativeObject">Newly created native object</param>
-        protected abstract void SetNativeObject(ref TNative nativeObject);
+        /// <param name="mesh1D">Newly created native object</param>
+        protected abstract void SetNativeObject(ref TNative mesh1D);
 
         /// <summary>
         /// Get the pointer to the pinned object

--- a/UGridNET/UGridNET/DisposableNativeObject.cs
+++ b/UGridNET/UGridNET/DisposableNativeObject.cs
@@ -53,8 +53,8 @@ namespace UGridNET
         /// <summary>
         /// Maps the <typeparamref name="TNative"/> object with current state (used in <see cref="CreateNativeObject"/>)
         /// </summary>
-        /// <param name="mesh1D">Newly created native object</param>
-        protected abstract void SetNativeObject(ref TNative mesh1D);
+        /// <param name="nativeObject">Newly created native object</param>
+        protected abstract void SetNativeObject(ref TNative nativeObject);
 
         /// <summary>
         /// Get the pointer to the pinned object

--- a/UGridNET/UGridNET/Mesh1DExtensions.cs
+++ b/UGridNET/UGridNET/Mesh1DExtensions.cs
@@ -22,6 +22,7 @@ namespace UGridNET
                     mesh1D.edge_edge_id = IntPtrHelpers.AllocateZeroed<int>(mesh1D.num_edges);
                     mesh1D.node_edge_id = IntPtrHelpers.AllocateZeroed<int>(mesh1D.num_nodes);
                     mesh1D.node_edge_offset = IntPtrHelpers.AllocateZeroed<double>(mesh1D.num_nodes);
+                    mesh1D.grid_mapping = IntPtrHelpers.AllocateZeroed<byte>(UGrid.name_long_length);
                 }
                 catch
                 {
@@ -49,6 +50,7 @@ namespace UGridNET
                 IntPtrHelpers.Free(() => mesh1D.edge_edge_id, value => mesh1D.edge_edge_id = value);
                 IntPtrHelpers.Free(() => mesh1D.node_edge_id, value => mesh1D.node_edge_id = value);
                 IntPtrHelpers.Free(() => mesh1D.node_edge_offset, value => mesh1D.node_edge_offset = value);
+                IntPtrHelpers.Free(() => mesh1D.grid_mapping, value => mesh1D.grid_mapping = value);
             }
         }
     }

--- a/UGridNET/UGridNET/Mesh2DExtensions.cs
+++ b/UGridNET/UGridNET/Mesh2DExtensions.cs
@@ -28,6 +28,7 @@ namespace UGridNET
                     mesh2D.face_nodes = IntPtrHelpers.AllocateZeroed<int>(mesh2D.num_faces * mesh2D.num_face_nodes_max);
                     mesh2D.face_edges = IntPtrHelpers.AllocateZeroed<int>(mesh2D.num_faces * mesh2D.num_face_nodes_max);
                     mesh2D.face_faces = IntPtrHelpers.AllocateZeroed<int>(mesh2D.num_faces * mesh2D.num_face_nodes_max);
+                    mesh2D.grid_mapping = IntPtrHelpers.AllocateZeroed<byte>(UGrid.name_long_length);
                 }
                 catch
                 {
@@ -61,6 +62,7 @@ namespace UGridNET
                 IntPtrHelpers.Free(() => mesh2D.face_nodes, value => mesh2D.face_nodes = value);
                 IntPtrHelpers.Free(() => mesh2D.face_edges, value => mesh2D.face_edges = value);
                 IntPtrHelpers.Free(() => mesh2D.face_faces, value => mesh2D.face_faces = value);
+                IntPtrHelpers.Free(() => mesh2D.grid_mapping, value => mesh2D.grid_mapping = value);
             }
         }
     }

--- a/UGridNET/UGridNET/Network1DExtensions.cs
+++ b/UGridNET/UGridNET/Network1DExtensions.cs
@@ -24,6 +24,7 @@ namespace UGridNET
                     network1D.geometry_nodes_x = IntPtrHelpers.AllocateZeroed<double>(network1D.num_geometry_nodes);
                     network1D.geometry_nodes_y = IntPtrHelpers.AllocateZeroed<double>(network1D.num_geometry_nodes);
                     network1D.num_edge_geometry_nodes = IntPtrHelpers.AllocateZeroed<int>(network1D.num_edges);
+                    network1D.grid_mapping = IntPtrHelpers.AllocateZeroed<byte>(UGrid.name_long_length);
                 }
                 catch
                 {
@@ -53,6 +54,7 @@ namespace UGridNET
                 IntPtrHelpers.Free(() => network1D.geometry_nodes_x, value => network1D.geometry_nodes_x = value);
                 IntPtrHelpers.Free(() => network1D.geometry_nodes_y, value => network1D.geometry_nodes_y = value);
                 IntPtrHelpers.Free(() => network1D.num_edge_geometry_nodes, value => network1D.num_edge_geometry_nodes = value);
+                IntPtrHelpers.Free(() => network1D.grid_mapping, value => network1D.grid_mapping = value);
             }
         }
     }

--- a/UGridNET/UGridNET/UGridWriter.cs
+++ b/UGridNET/UGridNET/UGridWriter.cs
@@ -47,96 +47,66 @@ namespace UGridNET
             }
         }
 
-        public void AddProjectedCoordinateSystem(ProjectedCoordinateSystem projectedCoordinateSystem)
+        public void AddCoordinateSystem(CoordinateSystem coordinateSystem)
         {
-            var variableNameStr = "projected_coordinate_system";
-            if (projectedCoordinateSystem.EPSG.Equals(4326))
-            {
-                variableNameStr = "wgs84";
-            }
-
-            byte[] variableName = variableNameStr.GetRightPaddedNullTerminatedBytes(UGrid.name_long_length);
+            byte[] variableName = coordinateSystem.VariableName.GetRightPaddedNullTerminatedBytes(UGrid.name_long_length);
             Invoke(() => UGrid.ug_variable_int_define(FileID, variableName));
 
-            // integer attributes
+            Invoke(() => UGrid.ug_attribute_char_define(
+                       FileID,
+                       variableName,
+                       "name".GetRightPaddedNullTerminatedBytes(UGrid.name_long_length),
+                       coordinateSystem.Name.GetRightPaddedNullTerminatedBytes(coordinateSystem.Name.Length + 1),
+                       coordinateSystem.Name.Length));
+            
             Invoke(() => UGrid.ug_attribute_int_define(
                        FileID,
                        variableName,
                        "epsg".GetRightPaddedNullTerminatedBytes(UGrid.name_long_length),
-                       new[] { projectedCoordinateSystem.EPSG },
+                       new[] { coordinateSystem.EPSG },
                        1));
+            
+            Invoke(() => UGrid.ug_attribute_char_define(
+                       FileID,
+                       variableName,
+                       "grid_mapping_name".GetRightPaddedNullTerminatedBytes(UGrid.name_long_length),
+                       coordinateSystem.GridMappingName.GetRightPaddedNullTerminatedBytes(coordinateSystem.GridMappingName.Length + 1),
+                       coordinateSystem.GridMappingName.Length));
 
-            // double attributes
             Invoke(() => UGrid.ug_attribute_double_define(
                        FileID,
                        variableName,
                        "longitude_of_prime_meridian".GetRightPaddedNullTerminatedBytes(UGrid.name_long_length),
-                       new[] { projectedCoordinateSystem.LongitudeOfPrimeMeridian },
+                       new[] { coordinateSystem.LongitudeOfPrimeMeridian },
                        1));
 
             Invoke(() => UGrid.ug_attribute_double_define(
                        FileID,
                        variableName,
                        "semi_major_axis".GetRightPaddedNullTerminatedBytes(UGrid.name_long_length),
-                       new[] { projectedCoordinateSystem.SemiMajorAxis },
+                       new[] { coordinateSystem.SemiMajorAxis },
                        1));
 
             Invoke(() => UGrid.ug_attribute_double_define(
                        FileID,
                        variableName,
                        "semi_minor_axis".GetRightPaddedNullTerminatedBytes(UGrid.name_long_length),
-                       new[] { projectedCoordinateSystem.SemiMinorAxis },
+                       new[] { coordinateSystem.SemiMinorAxis },
                        1));
 
             Invoke(() => UGrid.ug_attribute_double_define(
                        FileID,
                        variableName,
                        "inverse_flattening".GetRightPaddedNullTerminatedBytes(UGrid.name_long_length),
-                       new[] { projectedCoordinateSystem.InverseFlattening },
+                       new[] { coordinateSystem.InverseFlattening },
                        1));
-
-            // string attributes
-            Invoke(() => UGrid.ug_attribute_char_define(
-                       FileID,
-                       variableName,
-                       "name".GetRightPaddedNullTerminatedBytes(UGrid.name_long_length),
-                       projectedCoordinateSystem.Name.GetRightPaddedNullTerminatedBytes(projectedCoordinateSystem.Name.Length + 1),
-                       projectedCoordinateSystem.Name.Length));
-
-            Invoke(() => UGrid.ug_attribute_char_define(
-                       FileID,
-                       variableName,
-                       "grid_mapping_name".GetRightPaddedNullTerminatedBytes(UGrid.name_long_length),
-                       projectedCoordinateSystem.GridMappingName.GetRightPaddedNullTerminatedBytes(projectedCoordinateSystem.GridMappingName.Length + 1),
-                       projectedCoordinateSystem.GridMappingName.Length));
-
-            Invoke(() => UGrid.ug_attribute_char_define(
-                       FileID,
-                       variableName,
-                       "proj4_params".GetRightPaddedNullTerminatedBytes(UGrid.name_long_length),
-                       projectedCoordinateSystem.Proj4Params.GetRightPaddedNullTerminatedBytes(projectedCoordinateSystem.Proj4Params.Length + 1),
-                       projectedCoordinateSystem.Proj4Params.Length));
-
+            
             Invoke(() => UGrid.ug_attribute_char_define(
                        FileID,
                        variableName,
                        "EPSG_code".GetRightPaddedNullTerminatedBytes(UGrid.name_long_length),
-                       projectedCoordinateSystem.EPSGCode.GetRightPaddedNullTerminatedBytes(projectedCoordinateSystem.EPSGCode.Length + 1),
-                       projectedCoordinateSystem.EPSGCode.Length));
-
-            Invoke(() => UGrid.ug_attribute_char_define(
-                       FileID,
-                       variableName,
-                       "projection_name".GetRightPaddedNullTerminatedBytes(UGrid.name_long_length),
-                       projectedCoordinateSystem.ProjectionName.GetRightPaddedNullTerminatedBytes(projectedCoordinateSystem.ProjectionName.Length + 1),
-                       projectedCoordinateSystem.ProjectionName.Length));
-
-            Invoke(() => UGrid.ug_attribute_char_define(
-                       FileID,
-                       variableName,
-                       "wkt".GetRightPaddedNullTerminatedBytes(UGrid.name_long_length),
-                       projectedCoordinateSystem.WKT.GetRightPaddedNullTerminatedBytes(projectedCoordinateSystem.WKT.Length + 1),
-                       projectedCoordinateSystem.WKT.Length));
+                       coordinateSystem.EPSGCode.GetRightPaddedNullTerminatedBytes(coordinateSystem.EPSGCode.Length + 1),
+                       coordinateSystem.EPSGCode.Length));
         }
 
         private void WriteMesh1D()


### PR DESCRIPTION
This PR updates the UGRID file format to better conform to CF conventions.

**Changes**
- Added `start_index` attribute to index variables for compatibility with tools such as QGIS
- Added `grid_mapping` attribute to topology coordinate variables to explicitly link them to the coordinate system variable
- Fixed coordinate attributes (`units`, `standard_name`, `long_name`) for spherical coordinate systems to use geographic conventions (e.g. `degrees_east`/`degrees_north` and `longitude`/`latitude`) instead of projected ones
- Removed unused attributes from the coordinate system variable (`proj4_params`, `projection_name`, `wkt`)

**UGRID file format diffs**

2D Mesh (Amersfoort / RD New)
<img width="2533" height="1387" alt="image" src="https://github.com/user-attachments/assets/ad4c2c4a-0633-4435-b0e6-e44cfdceea5a" />

2D Mesh (WGS84)
<img width="2546" height="1404" alt="image" src="https://github.com/user-attachments/assets/dd37ceb6-1636-45e9-984e-0b9e47732db7" />